### PR TITLE
Created SPA Mode Setting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@
 
 var each = require('component-each');
 var integration = require('@segment/analytics.js-integration');
-var tick = require('next-tick');
+var tick = require('next-tick-browser');
 
 /**
  * Expose `VWO` integration.

--- a/lib/index.js
+++ b/lib/index.js
@@ -127,6 +127,8 @@ VWO.prototype.roots = function() {
 
 VWO.prototype.page = function() {
   console.log("isSpa", this.options.isSpa);
+  var self = this;
+
   if (this.options.isSpa) {
     if (this.options.replay) {
       tick(function() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ var replayCache = [];
 var listenCache = [];
 var spaMode = false;
 var findExperiments = function (experimentIds, type) {
-  if (spaMode) {
+  // if (spaMode) {
     var cache = (type === "listen") ? listenCache : replayCache;
     var clean = [];
 
@@ -25,32 +25,45 @@ var findExperiments = function (experimentIds, type) {
       }
     };
 
-    console.log("before", clean.length);
-    if (cache.length <= 0) {
+    console.log("before", experimentIds, clean, cache);
 
-      console.log("cache init");
-      experimentIds.forEach(function (id) {
-        clean.push(id);
-        pushIt(id);
-      });
+    experimentIds.forEach(function (key, i) {
+      if (cache.indexOf(key) === -1) {
+        pushIt(key);
+        clean.push(key);
+      }
+    });
 
-    } else {
 
-      cache.forEach(function (key, i) {
-        console.log(key, i);
-        if (experimentIds.indexOf(key) === -1) {
-          console.log("new");
-          clean.push(key);
-          pushIt(key)
-        }
-      });
-
-    }
-    console.log("after", clean.length);
+    // if (cache.length <= 0) {
+    //
+    //   console.log("cache init");
+    //
+    //   experimentIds.forEach(function (id) {
+    //     clean.push(id);
+    //     pushIt(id);
+    //   });
+    //
+    // } else {
+    //
+    //   cache.forEach(function (key, i) {
+    //
+    //     console.log(key, i);
+    //
+    //     if (experimentIds.indexOf(key) === -1) {
+    //       console.log("new");
+    //       clean.push(key);
+    //       pushIt(key)
+    //     }
+    //
+    //   });
+    //
+    // }
+    console.log("after", experimentIds, clean, cache);
     return clean;
-  } else {
-    return experimentIds;
-  }
+  // } else {
+  //   return experimentIds;
+  // }
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -132,6 +132,8 @@ VWO.prototype.roots = function() {
 
 VWO.prototype.page = function() {
   console.log("isSpa", this.options.isSpa);
+  console.log("listen", listenCache.length);
+  console.log("replay", replayCache.length);
   var self = this;
 
   if (this.options.isSpa) {
@@ -152,7 +154,7 @@ VWO.prototype.page = function() {
 
 function findExperiments(experimentIds, cache) {
   var clean = experimentIds.slice();
-  console.log("before", clean.length, dedupedArray);
+  console.log("before", clean.length);
   //if (true) {/
     // If SPA is active, then dedupe experiment calls
     if (cache.length <= 0) {
@@ -170,7 +172,7 @@ function findExperiments(experimentIds, cache) {
       });
     }
   //}
-  console.log("after", clean.length, dedupedArray);
+  console.log("after", clean.length);
   return clean;
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,10 @@ var each = require('component-each');
 var integration = require('@segment/analytics.js-integration');
 var tick = require('browser-next-tick');
 
+var replayIdCache = [];
+var listenIdCache = [];
+var spaMode = false;
+
 /**
  * Expose `VWO` integration.
  */
@@ -47,6 +51,7 @@ VWO.prototype.initialize = function() {
     var library_tolerance = this.options.libraryTolerance;
     var use_existing_jquery = this.options.useExistingJQuery;
     var is_spa = (this.options.isSpa) ? '&f=1' : '';
+    spaMode = this.options.isSpa;
 
     window._vwo_code=(function(){f=false,d=document;return{use_existing_jquery:function(){return use_existing_jquery;},library_tolerance:function(){return library_tolerance;},finish:function(){if(!f){f=true;var a=d.getElementById('_vis_opt_path_hides');if(a)a.parentNode.removeChild(a);}},finished:function(){return f;},load:function(a){var b=d.createElement('script');b.src=a;b.type='text/javascript';b.innerText;b.onerror=function(){_vwo_code.finish();};d.getElementsByTagName('head')[0].appendChild(b);},init:function(){settings_timer=setTimeout('_vwo_code.finish()',settings_tolerance);var a=d.createElement('style'),b='body{opacity:0 !important;filter:alpha(opacity=0) !important;background:none !important;}',h=d.getElementsByTagName('head')[0];a.setAttribute('id','_vis_opt_path_hides');a.setAttribute('type','text/css');if(a.styleSheet)a.styleSheet.cssText=b;else a.appendChild(d.createTextNode(b));h.appendChild(a);this.load('//dev.visualwebsiteoptimizer.com/j.php?a='+account_id+'&u='+encodeURIComponent(d.URL)+'&r='+Math.random()+is_spa);return settings_timer;}};}());_vwo_settings_timer=_vwo_code.init();
     /* eslint-enable */
@@ -145,6 +150,31 @@ VWO.prototype.page = function() {
 };
 // TODO: Add SPA hook to track and push new experiment updates on page calls
 
+function findExperiments(expArray, type) {
+  var dedupedArray = expArray.splice();
+  console.log("before", dedupedArray.length, dedupedArray);
+  if (spaMode && type === "listen") {
+    // If SPA is active, then dedupe experiment calls
+    listenIdCache.forEach(function(key, i){
+      if (dedupedArray.indexOf(key) !== -1) {
+        dedupedArray.splice(i, 1);
+      } else {
+        listenIdCache.push(key)
+      }
+    });
+  } else if (spaMode && type === "replay") {
+    replayIdCache.forEach(function(key, i){
+      if (dedupedArray.indexOf(key) !== -1) {
+        dedupedArray.splice(i, 1);
+      } else {
+        replayIdCache.push(key)
+      }
+    });
+  }
+  console.log("after", dedupedArray.length, dedupedArray);
+  return dedupedArray;
+}
+
 /**
  * Get dictionary of experiment keys and variations.
  *
@@ -157,7 +187,7 @@ VWO.prototype.page = function() {
 function rootExperiments(fn) {
   enqueue(function() {
     var data = {};
-    var experimentIds = window._vwo_exp_ids;
+    var experimentIds = findExperiments(window._vwo_exp_ids, 'listen');
     if (!experimentIds) return fn();
     each(experimentIds, function(experimentId) {
       var variationName = variation(experimentId);
@@ -179,7 +209,7 @@ function rootExperiments(fn) {
 function experiments(fn) {
   enqueue(function() {
     var data = {};
-    var ids = window._vwo_exp_ids;
+    var ids = findExperiments(window._vwo_exp_ids, 'listen');
     if (!ids) return fn();
     each(ids, function(id) {
       var name = variation(id);

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,31 @@ var tick = require('browser-next-tick');
 var replayCache = [];
 var listenCache = [];
 var spaMode = false;
+var findExperiments= function (experimentIds, type) {
+  var cache = (type === "listen") ? listenCache : replayCache;
+  var clean = experimentIds.slice();
+  console.log("before", clean.length);
+  //if (true) {/
+  // If SPA is active, then dedupe experiment calls
+  if (cache.length <= 0) {
+    console.log("cache init");
+      cache = clean.slice();
+  } else {
+    cache.forEach(function(key, i){
+      console.log(key, i);
+      if (clean.indexOf(key) !== -1) {
+        console.log("exists");
+        clean.splice(i, 1);
+      } else {
+        console.log("new");
+        cache.push(key)
+      }
+    });
+  }
+  //}
+  console.log("after", clean.length);
+  return clean;
+};
 
 /**
  * Expose `VWO` integration.
@@ -150,31 +175,6 @@ VWO.prototype.page = function() {
     }
   }
 };
-// TODO: Add SPA hook to track and push new experiment updates on page calls
-
-function findExperiments(experimentIds, cache) {
-  var clean = experimentIds.slice();
-  console.log("before", clean.length);
-  //if (true) {/
-    // If SPA is active, then dedupe experiment calls
-    if (cache.length <= 0) {
-      cache = clean.slice();
-    } else {
-      cache.forEach(function(key, i){
-        console.log(key, i);
-        if (clean.indexOf(key) !== -1) {
-          console.log("exists");
-          clean.splice(i, 1);
-        } else {
-          console.log("new");
-          cache.push(key)
-        }
-      });
-    }
-  //}
-  console.log("after", clean.length);
-  return clean;
-}
 
 /**
  * Get dictionary of experiment keys and variations.
@@ -188,7 +188,7 @@ function findExperiments(experimentIds, cache) {
 function rootExperiments(fn) {
   enqueue(function() {
     var data = {};
-    var experimentIds = findExperiments(window._vwo_exp_ids, listenCache);
+    var experimentIds = findExperiments(window._vwo_exp_ids, "listen");
     if (!experimentIds) return fn();
     each(experimentIds, function(experimentId) {
       var variationName = variation(experimentId);
@@ -210,7 +210,7 @@ function rootExperiments(fn) {
 function experiments(fn) {
   enqueue(function() {
     var data = {};
-    var ids = findExperiments(window._vwo_exp_ids, replayCache);
+    var ids = findExperiments(window._vwo_exp_ids, "replay");
     if (!ids) return fn();
     each(ids, function(id) {
       var name = variation(id);

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,15 +11,25 @@ var tick = require('browser-next-tick');
 var replayCache = [];
 var listenCache = [];
 var spaMode = false;
-var findExperiments= function (experimentIds, type) {
+var findExperiments = function (experimentIds, type) {
   var cache = (type === "listen") ? listenCache : replayCache;
   var clean = experimentIds.slice();
+  var pushIt = function (value) {
+    if (type === "replay") {
+      replayCache.push(value);
+    }
+    if (type === "listen") {
+      listenCache.push(value);
+    }
+  };
   console.log("before", clean.length);
   //if (true) {/
   // If SPA is active, then dedupe experiment calls
   if (cache.length <= 0) {
     console.log("cache init");
-      cache = clean.slice();
+    clean.forEach(function (id) {
+      pushIt(id);
+    });
   } else {
     cache.forEach(function(key, i){
       console.log(key, i);
@@ -28,7 +38,7 @@ var findExperiments= function (experimentIds, type) {
         clean.splice(i, 1);
       } else {
         console.log("new");
-        cache.push(key)
+        pushIt(key)
       }
     });
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -153,19 +153,23 @@ VWO.prototype.page = function() {
 function findExperiments(experimentIds, cache) {
   var clean = experimentIds.slice();
   console.log("before", clean.length, dedupedArray);
-  if (true) {
+  //if (true) {/
     // If SPA is active, then dedupe experiment calls
-    cache.forEach(function(key, i){
-      console.log(key, i);
-      if (clean.indexOf(key) !== -1) {
-        console.log("exists");
-        clean.splice(i, 1);
-      } else {
-        console.log("new");
-        cache.push(key)
-      }
-    });
-  }
+    if (cache.length <= 0) {
+      cache = clean.slice();
+    } else {
+      cache.forEach(function(key, i){
+        console.log(key, i);
+        if (clean.indexOf(key) !== -1) {
+          console.log("exists");
+          clean.splice(i, 1);
+        } else {
+          console.log("new");
+          cache.push(key)
+        }
+      });
+    }
+  //}
   console.log("after", clean.length, dedupedArray);
   return clean;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -151,18 +151,23 @@ VWO.prototype.page = function() {
 // TODO: Add SPA hook to track and push new experiment updates on page calls
 
 function findExperiments(expArray, type) {
-  var dedupedArray = expArray.splice();
+  var dedupedArray = expArray.slice();
   console.log("before", dedupedArray.length, dedupedArray);
   if (spaMode && type === "listen") {
+    console.log("listen");
     // If SPA is active, then dedupe experiment calls
     listenIdCache.forEach(function(key, i){
+      console.log(key, i);
       if (dedupedArray.indexOf(key) !== -1) {
+        console.log("exists");
         dedupedArray.splice(i, 1);
       } else {
+        console.log("new");
         listenIdCache.push(key)
       }
     });
   } else if (spaMode && type === "replay") {
+    console.log("replay");
     replayIdCache.forEach(function(key, i){
       if (dedupedArray.indexOf(key) !== -1) {
         dedupedArray.splice(i, 1);
@@ -209,7 +214,7 @@ function rootExperiments(fn) {
 function experiments(fn) {
   enqueue(function() {
     var data = {};
-    var ids = findExperiments(window._vwo_exp_ids, 'listen');
+    var ids = findExperiments(window._vwo_exp_ids, 'replay');
     if (!ids) return fn();
     each(ids, function(id) {
       var name = variation(id);

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,8 +8,8 @@ var each = require('component-each');
 var integration = require('@segment/analytics.js-integration');
 var tick = require('browser-next-tick');
 
-var replayIdCache = [];
-var listenIdCache = [];
+var replayCache = [];
+var listenCache = [];
 var spaMode = false;
 
 /**
@@ -150,34 +150,24 @@ VWO.prototype.page = function() {
 };
 // TODO: Add SPA hook to track and push new experiment updates on page calls
 
-function findExperiments(expArray, type) {
-  var dedupedArray = expArray.slice();
-  console.log("before", dedupedArray.length, dedupedArray);
-  if (spaMode && type === "listen") {
-    console.log("listen");
+function findExperiments(experimentIds, cache) {
+  var clean = experimentIds.slice();
+  console.log("before", clean.length, dedupedArray);
+  if (true) {
     // If SPA is active, then dedupe experiment calls
-    listenIdCache.forEach(function(key, i){
+    cache.forEach(function(key, i){
       console.log(key, i);
-      if (dedupedArray.indexOf(key) !== -1) {
+      if (clean.indexOf(key) !== -1) {
         console.log("exists");
-        dedupedArray.splice(i, 1);
+        clean.splice(i, 1);
       } else {
         console.log("new");
-        listenIdCache.push(key)
-      }
-    });
-  } else if (spaMode && type === "replay") {
-    console.log("replay");
-    replayIdCache.forEach(function(key, i){
-      if (dedupedArray.indexOf(key) !== -1) {
-        dedupedArray.splice(i, 1);
-      } else {
-        replayIdCache.push(key)
+        cache.push(key)
       }
     });
   }
-  console.log("after", dedupedArray.length, dedupedArray);
-  return dedupedArray;
+  console.log("after", clean.length, dedupedArray);
+  return clean;
 }
 
 /**
@@ -192,7 +182,7 @@ function findExperiments(expArray, type) {
 function rootExperiments(fn) {
   enqueue(function() {
     var data = {};
-    var experimentIds = findExperiments(window._vwo_exp_ids, 'listen');
+    var experimentIds = findExperiments(window._vwo_exp_ids, listenCache);
     if (!experimentIds) return fn();
     each(experimentIds, function(experimentId) {
       var variationName = variation(experimentId);
@@ -214,7 +204,7 @@ function rootExperiments(fn) {
 function experiments(fn) {
   enqueue(function() {
     var data = {};
-    var ids = findExperiments(window._vwo_exp_ids, 'replay');
+    var ids = findExperiments(window._vwo_exp_ids, replayCache);
     if (!ids) return fn();
     each(ids, function(id) {
       var name = variation(id);

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ var tick = require('browser-next-tick');
 var replayCache = [];
 var listenCache = [];
 var spaMode = false;
-var findExperiments = function (experimentIds, type) {
+var findExperiments = function (experiments, type) {
   // if (spaMode) {
     var cache = (type === "listen") ? listenCache : replayCache;
     var clean = [];
@@ -25,15 +25,20 @@ var findExperiments = function (experimentIds, type) {
       }
     };
 
-    console.log("before", experimentIds, clean, cache);
+    console.log("before", experiments, clean, cache);
 
-    experimentIds.forEach(function (key, i) {
+    // Re
+
+    Object.keys(experiments).forEach(function (key) {
       if (cache.indexOf(key) === -1) {
-        pushIt(key);
+        if (experiments[key].ready && !window._vis_debug && experiments[key].combination_chosen) {
+          pushIt(key);
+        }
         clean.push(key);
       }
     });
 
+    // Return an array the ids of experiments not ready and those ready for the first time
 
     // if (cache.length <= 0) {
     //
@@ -59,7 +64,7 @@ var findExperiments = function (experimentIds, type) {
     //   });
     //
     // }
-    console.log("after", experimentIds, clean, cache);
+    console.log("after", experiments, clean, cache);
     return clean;
   // } else {
   //   return experimentIds;

--- a/lib/index.js
+++ b/lib/index.js
@@ -125,6 +125,24 @@ VWO.prototype.roots = function() {
   });
 };
 
+VWO.prototype.page = function() {
+  console.log("isSpa", this.options.isSpa);
+  if (this.options.isSpa) {
+    if (this.options.replay) {
+      tick(function() {
+        self.replay();
+      });
+    }
+
+    if (this.options.listen) {
+      tick(function() {
+        self.roots();
+      });
+    }
+  }
+};
+// TODO: Add SPA hook to track and push new experiment updates on page calls
+
 /**
  * Get dictionary of experiment keys and variations.
  *

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@
 
 var each = require('component-each');
 var integration = require('@segment/analytics.js-integration');
-var tick = require('next-tick-browser');
+var tick = require('browser-next-tick');
 
 /**
  * Expose `VWO` integration.

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,64 +11,45 @@ var tick = require('browser-next-tick');
 var replayCache = [];
 var listenCache = [];
 var spaMode = false;
-var findExperiments = function (experiments, type) {
-  // if (spaMode) {
-    var cache = (type === "listen") ? listenCache : replayCache;
-    var clean = [];
+var findExperiments = function(experiments, type) {
+  // Array of _vwo_exp_ids that we will return that have not been added to the cache
+  var clean = [];
+  if (spaMode) {
+    // If the app is a SPA, then we need to filter the experiment ids that have already been sent
 
-    var pushIt = function (value) {
-      if (type === "replay") {
+    // Loading the cache of the type of event that needs to fire, so if both listen and track are selected they can both fire the same event
+    var cache = type === 'listen' ? listenCache : replayCache;
+
+
+    // Function to push new id to be cached into the correct cache
+    var pushIt = function(value) {
+      if (type === 'replay') {
         replayCache.push(value);
       }
-      if (type === "listen") {
+      if (type === 'listen') {
         listenCache.push(value);
       }
     };
 
-    console.log("before", experiments, clean, cache);
-
-    // Re
-
-    Object.keys(experiments).forEach(function (key) {
+    // Loop thru the active experiments and see what needs to be cached and what needs to sent to be tracked
+    Object.keys(experiments).forEach(function(key) {
       if (cache.indexOf(key) === -1) {
-        if (experiments[key].ready && !window._vis_debug && experiments[key].combination_chosen) {
+        if (experiments[key].ready && experiments[key].combination_chosen) {
+          // If the experiment is active, let's cache it's id so it doesn't fire a duplicate track event
           pushIt(key);
+          // It's fine to add to the returned array this time, as it will be the first time it's fired and will be blocked next time
         }
+        // Push all non-cached keys to the array we will return
         clean.push(key);
       }
     });
 
     // Return an array the ids of experiments not ready and those ready for the first time
-
-    // if (cache.length <= 0) {
-    //
-    //   console.log("cache init");
-    //
-    //   experimentIds.forEach(function (id) {
-    //     clean.push(id);
-    //     pushIt(id);
-    //   });
-    //
-    // } else {
-    //
-    //   cache.forEach(function (key, i) {
-    //
-    //     console.log(key, i);
-    //
-    //     if (experimentIds.indexOf(key) === -1) {
-    //       console.log("new");
-    //       clean.push(key);
-    //       pushIt(key)
-    //     }
-    //
-    //   });
-    //
-    // }
-    console.log("after", experiments, clean, cache);
-    return clean;
-  // } else {
-  //   return experimentIds;
-  // }
+  } else {
+    // If the app is not a SPA, just return the ids that VWO manage
+    clean = window._vwo_exp_ids;
+  }
+  return clean;
 };
 
 /**
@@ -190,9 +171,6 @@ VWO.prototype.roots = function() {
 };
 
 VWO.prototype.page = function() {
-  console.log("isSpa", this.options.isSpa);
-  console.log("listen", listenCache.length);
-  console.log("replay", replayCache.length);
   var self = this;
 
   if (this.options.isSpa) {
@@ -222,7 +200,7 @@ VWO.prototype.page = function() {
 function rootExperiments(fn) {
   enqueue(function() {
     var data = {};
-    var experimentIds = findExperiments(window._vwo_exp_ids, "listen");
+    var experimentIds = findExperiments(window._vwo_exp, 'listen');
     if (!experimentIds) return fn();
     each(experimentIds, function(experimentId) {
       var variationName = variation(experimentId);
@@ -244,7 +222,7 @@ function rootExperiments(fn) {
 function experiments(fn) {
   enqueue(function() {
     var data = {};
-    var ids = findExperiments(window._vwo_exp_ids, "replay");
+    var ids = findExperiments(window._vwo_exp, 'replay');
     if (!ids) return fn();
     each(ids, function(id) {
       var name = variation(id);

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,8 @@ var VWO = module.exports = integration('Visual Website Optimizer')
   .option('libraryTolerance', 2500)
   .option('useExistingJQuery', false)
   .option('replay', true)
-  .option('listen', false);
+  .option('listen', false)
+  .option('is_spa', false);
 
 /**
  * The context for this integration.
@@ -45,8 +46,9 @@ VWO.prototype.initialize = function() {
     var settings_tolerance = this.options.settingsTolerance;
     var library_tolerance = this.options.libraryTolerance;
     var use_existing_jquery = this.options.useExistingJQuery;
+    var is_spa = (this.options.is_spa) ? '&f=1' : '';
 
-    window._vwo_code=(function(){f=false,d=document;return{use_existing_jquery:function(){return use_existing_jquery;},library_tolerance:function(){return library_tolerance;},finish:function(){if(!f){f=true;var a=d.getElementById('_vis_opt_path_hides');if(a)a.parentNode.removeChild(a);}},finished:function(){return f;},load:function(a){var b=d.createElement('script');b.src=a;b.type='text/javascript';b.innerText;b.onerror=function(){_vwo_code.finish();};d.getElementsByTagName('head')[0].appendChild(b);},init:function(){settings_timer=setTimeout('_vwo_code.finish()',settings_tolerance);var a=d.createElement('style'),b='body{opacity:0 !important;filter:alpha(opacity=0) !important;background:none !important;}',h=d.getElementsByTagName('head')[0];a.setAttribute('id','_vis_opt_path_hides');a.setAttribute('type','text/css');if(a.styleSheet)a.styleSheet.cssText=b;else a.appendChild(d.createTextNode(b));h.appendChild(a);this.load('//dev.visualwebsiteoptimizer.com/j.php?a='+account_id+'&u='+encodeURIComponent(d.URL)+'&r='+Math.random());return settings_timer;}};}());_vwo_settings_timer=_vwo_code.init();
+    window._vwo_code=(function(){f=false,d=document;return{use_existing_jquery:function(){return use_existing_jquery;},library_tolerance:function(){return library_tolerance;},finish:function(){if(!f){f=true;var a=d.getElementById('_vis_opt_path_hides');if(a)a.parentNode.removeChild(a);}},finished:function(){return f;},load:function(a){var b=d.createElement('script');b.src=a;b.type='text/javascript';b.innerText;b.onerror=function(){_vwo_code.finish();};d.getElementsByTagName('head')[0].appendChild(b);},init:function(){settings_timer=setTimeout('_vwo_code.finish()',settings_tolerance);var a=d.createElement('style'),b='body{opacity:0 !important;filter:alpha(opacity=0) !important;background:none !important;}',h=d.getElementsByTagName('head')[0];a.setAttribute('id','_vis_opt_path_hides');a.setAttribute('type','text/css');if(a.styleSheet)a.styleSheet.cssText=b;else a.appendChild(d.createTextNode(b));h.appendChild(a);this.load('//dev.visualwebsiteoptimizer.com/j.php?a='+account_id+'&u='+encodeURIComponent(d.URL)+'&r='+Math.random()+is_spa);return settings_timer;}};}());_vwo_settings_timer=_vwo_code.init();
     /* eslint-enable */
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@ var VWO = module.exports = integration('Visual Website Optimizer')
   .option('useExistingJQuery', false)
   .option('replay', true)
   .option('listen', false)
-  .option('is_spa', false);
+  .option('isSpa', false);
 
 /**
  * The context for this integration.
@@ -46,7 +46,7 @@ VWO.prototype.initialize = function() {
     var settings_tolerance = this.options.settingsTolerance;
     var library_tolerance = this.options.libraryTolerance;
     var use_existing_jquery = this.options.useExistingJQuery;
-    var is_spa = (this.options.is_spa) ? '&f=1' : '';
+    var is_spa = (this.options.isSpa) ? '&f=1' : '';
 
     window._vwo_code=(function(){f=false,d=document;return{use_existing_jquery:function(){return use_existing_jquery;},library_tolerance:function(){return library_tolerance;},finish:function(){if(!f){f=true;var a=d.getElementById('_vis_opt_path_hides');if(a)a.parentNode.removeChild(a);}},finished:function(){return f;},load:function(a){var b=d.createElement('script');b.src=a;b.type='text/javascript';b.innerText;b.onerror=function(){_vwo_code.finish();};d.getElementsByTagName('head')[0].appendChild(b);},init:function(){settings_timer=setTimeout('_vwo_code.finish()',settings_tolerance);var a=d.createElement('style'),b='body{opacity:0 !important;filter:alpha(opacity=0) !important;background:none !important;}',h=d.getElementsByTagName('head')[0];a.setAttribute('id','_vis_opt_path_hides');a.setAttribute('type','text/css');if(a.styleSheet)a.styleSheet.cssText=b;else a.appendChild(d.createTextNode(b));h.appendChild(a);this.load('//dev.visualwebsiteoptimizer.com/j.php?a='+account_id+'&u='+encodeURIComponent(d.URL)+'&r='+Math.random()+is_spa);return settings_timer;}};}());_vwo_settings_timer=_vwo_code.init();
     /* eslint-enable */

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,39 +12,45 @@ var replayCache = [];
 var listenCache = [];
 var spaMode = false;
 var findExperiments = function (experimentIds, type) {
-  var cache = (type === "listen") ? listenCache : replayCache;
-  var clean = experimentIds.slice();
-  var pushIt = function (value) {
-    if (type === "replay") {
-      replayCache.push(value);
-    }
-    if (type === "listen") {
-      listenCache.push(value);
-    }
-  };
-  console.log("before", clean.length);
-  //if (true) {/
-  // If SPA is active, then dedupe experiment calls
-  if (cache.length <= 0) {
-    console.log("cache init");
-    clean.forEach(function (id) {
-      pushIt(id);
-    });
-  } else {
-    cache.forEach(function(key, i){
-      console.log(key, i);
-      if (clean.indexOf(key) !== -1) {
-        console.log("exists");
-        clean.splice(i, 1);
-      } else {
-        console.log("new");
-        pushIt(key)
+  if (spaMode) {
+    var cache = (type === "listen") ? listenCache : replayCache;
+    var clean = [];
+
+    var pushIt = function (value) {
+      if (type === "replay") {
+        replayCache.push(value);
       }
-    });
+      if (type === "listen") {
+        listenCache.push(value);
+      }
+    };
+
+    console.log("before", clean.length);
+    if (cache.length <= 0) {
+
+      console.log("cache init");
+      experimentIds.forEach(function (id) {
+        clean.push(id);
+        pushIt(id);
+      });
+
+    } else {
+
+      cache.forEach(function (key, i) {
+        console.log(key, i);
+        if (experimentIds.indexOf(key) === -1) {
+          console.log("new");
+          clean.push(key);
+          pushIt(key)
+        }
+      });
+
+    }
+    console.log("after", clean.length);
+    return clean;
+  } else {
+    return experimentIds;
   }
-  //}
-  console.log("after", clean.length);
-  return clean;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "homepage": "https://github.com/astronomer-integrations/analytics.js-integration-visual-website-optimizer#readme",
   "dependencies": {
     "@segment/analytics.js-integration": "^3.1.0",
-    "component-each": "^0.2.6",
-    "next-tick": "^0.2.2"
+    "browser-next-tick": "^1.1.0",
+    "component-each": "^0.2.6"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,7 +4,7 @@ var Analytics = require('@segment/analytics.js-core').constructor;
 var integration = require('@segment/analytics.js-integration');
 var sandbox = require('@segment/clear-env');
 var tester = require('@segment/analytics.js-integration-tester');
-var tick = require('next-tick');
+var tick = require('browser-next-tick');
 var VWO = require('../lib/');
 
 describe('Visual Website Optimizer', function() {


### PR DESCRIPTION
By enabling isSpa, we now do two things.

1. Add in the `f=1` flag on the async snippet request to VWO in order to download the SPA-enabled async snippet (if that is also enabled)
2. We figure out which experiments are active and fire `Experiment Viewed` events on every .page() call. 

Per #2, normally this integration only fires these events on initialization. This doesn't work for SPA as the snippet isn't re-initialized on every new "page". We still keep the _fire on init_ functionality... but now also monitor `window._vwo_exp` and evaluate with experiments became active since the last time we checked, firing off events to the rest of the tracking snippet destinations upon `.page()` calls.